### PR TITLE
Removing the Println statement in the Encode method

### DIFF
--- a/morse.go
+++ b/morse.go
@@ -1,7 +1,6 @@
 package morse
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -49,7 +48,6 @@ func (h *hacker) Encode(r io.Reader) ([]byte, error) {
 			encodedValue += " " + "/" + " "
 		}
 	}
-	fmt.Println(encodedValue)
 	return []byte(encodedValue), nil
 }
 


### PR DESCRIPTION
So that when we run: `go run docs/example.go` instead of getting:

```
-.-. --- -. ...- . .-. - / - .... .. ... / - --- / -- --- .-. ... .
Morse Code is: -.-. --- -. ...- . .-. - / - .... .. ... / - --- / -- --- .-. ... .
```

we get:
```
Morse Code is: -.-. --- -. ...- . .-. - / - .... .. ... / - --- / -- --- .-. ... .
```

as expected.